### PR TITLE
Cleanup SV and NL from sitemap-index

### DIFF
--- a/sitemap-index.xml
+++ b/sitemap-index.xml
@@ -31,12 +31,6 @@
     <loc>https://experienceleague-stage.adobe.com/it/sitemap-2.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://experienceleague-stage.adobe.com/nl/sitemap-1.xml</loc>
-  </sitemap>
-  <sitemap>
-    <loc>https://experienceleague-stage.adobe.com/nl/sitemap-2.xml</loc>
-  </sitemap>
-  <sitemap>
     <loc>https://experienceleague-stage.adobe.com/pt-br/sitemap-1.xml</loc>
   </sitemap>
   <sitemap>
@@ -53,12 +47,6 @@
   </sitemap>
   <sitemap>
     <loc>https://experienceleague-stage.adobe.com/ja/sitemap-2.xml</loc>
-  </sitemap>
-  <sitemap>
-    <loc>https://experienceleague-stage.adobe.com/sv/sitemap-1.xml</loc>
-  </sitemap>
-  <sitemap>
-    <loc>https://experienceleague-stage.adobe.com/sv/sitemap-2.xml</loc>
   </sitemap>
   <sitemap>
     <loc>https://experienceleague-stage.adobe.com/zh-hans/sitemap-1.xml</loc>


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.

<!-- Please also provide test paths following the template below. -->

Jira ID:

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://sitemap-cleanup--exlm-stage--adobe-experience-league.aem.live
- After: https://sitemap-cleanup--exlm-stage--adobe-experience-league.aem.live/en/browse?martech=off
- After: https://sitemap-cleanup--exlm-stage--adobe-experience-league.aem.live/en/browse/analytics?martech=off
- After: https://sitemap-cleanup--exlm-stage--adobe-experience-league.aem.live/en/docs?martech=off
- After: https://sitemap-cleanup--exlm-stage--adobe-experience-league.aem.live/en/docs/analytics?martech=off
- After: https://sitemap-cleanup--exlm-stage--adobe-experience-league.aem.live/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://sitemap-cleanup--exlm-stage--adobe-experience-league.aem.live/en/events?martech=off
- After: https://sitemap-cleanup--exlm-stage--adobe-experience-league.aem.live/en/playlists?martech=off
- After: https://sitemap-cleanup--exlm-stage--adobe-experience-league.aem.live/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://sitemap-cleanup--exlm-stage--adobe-experience-league.aem.live/en/perspectives?martech=off
- After: https://sitemap-cleanup--exlm-stage--adobe-experience-league.aem.live/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://sitemap-cleanup--exlm-stage--adobe-experience-league.aem.live/en/certification-home?martech=off
- After: https://sitemap-cleanup--exlm-stage--adobe-experience-league.aem.live/en/search?martech=off

## AI Review Notes

<!--
  Optional — fill this in to guide the automated Claude review.
  Each bullet tells Claude to accept the decision and not flag it.
  Examples:
    - Using inline style on `.hero` because the value comes from a content attribute and cannot be a class.
    - Skipping IntersectionObserver on this block — the third-party script must load eagerly per vendor requirement.
    - The eslint-disable on line 42 is intentional: the rule false-positives on this pattern.
-->