### PR TITLE
Sync changes from main branch

### DIFF
--- a/blocks/atomic-search/atomic-search.js
+++ b/blocks/atomic-search/atomic-search.js
@@ -16,6 +16,7 @@ import {
   debounce,
   generateAdobeTrackingData,
   resolveBlockLevelSkeleton,
+  normalizeContentTypeFilterValue,
 } from './components/atomic-search-utils.js';
 import { isMobile } from '../header/header-utils.js';
 import { COVEO_SEARCH_CUSTOM_EVENTS } from '../../scripts/search/search-utils.js';
@@ -29,7 +30,40 @@ import { COVEO_EXCLUDE_STALE_UPCOMING_AQ } from '../../scripts/browse-card/brows
 
 let placeholders = {};
 
+/**
+ * Some search entry points (e.g. the community platform's native search box) send Coveo's raw
+ * "Parent;Parent|Child" indexing notation, which is never a valid filter — sanitize it here too.
+ */
+function normalizeContentTypeHash() {
+  const hash = window.location.hash.slice(1);
+  if (!hash) return;
+
+  let changed = false;
+  const updatedSegments = hash.split('&').map((segment) => {
+    const eqIndex = segment.indexOf('=');
+    if (eqIndex === -1) return segment;
+    const key = segment.slice(0, eqIndex);
+    const rawValue = segment.slice(eqIndex + 1);
+    if (key !== 'f-el_contenttype' || !rawValue) return segment;
+
+    const normalizedValue = rawValue
+      .split(',')
+      .map((item) => encodeURIComponent(normalizeContentTypeFilterValue(decodeURIComponent(item))))
+      .join(',');
+
+    if (normalizedValue === rawValue) return segment;
+    changed = true;
+    return `${key}=${normalizedValue}`;
+  });
+
+  if (!changed) return;
+  const newHash = updatedSegments.join('&');
+  window.history.replaceState(null, '', `${window.location.pathname}${window.location.search}#${newHash}`);
+}
+
 export default function decorate(block) {
+  normalizeContentTypeHash();
+
   const renderAtomicShimmer = (insertBefore) => {
     const skeletonWrapper = htmlToElement(`<div class="atomic-search-load-skeleton">
       <div class="atomic-load-skeleton-head">

--- a/blocks/atomic-search/atomic-search.js
+++ b/blocks/atomic-search/atomic-search.js
@@ -48,7 +48,15 @@ function normalizeContentTypeHash() {
 
     const normalizedValue = rawValue
       .split(',')
-      .map((item) => encodeURIComponent(normalizeContentTypeFilterValue(decodeURIComponent(item))))
+      .map((item) => {
+        try {
+          return encodeURIComponent(normalizeContentTypeFilterValue(decodeURIComponent(item)));
+        } catch {
+          // Malformed percent-encoding in an externally-constructed URL — leave this value as-is
+          // rather than let decorate() throw and take down the whole block's render.
+          return item;
+        }
+      })
       .join(',');
 
     if (normalizedValue === rawValue) return segment;

--- a/blocks/atomic-search/components/atomic-search-utils.js
+++ b/blocks/atomic-search/components/atomic-search-utils.js
@@ -29,6 +29,26 @@ export const COMMUNITY_CONTENT_TYPES = [
 
 export const COMMUNITY_SUPPORTED_SORT_ELEMENTS = ['el_view_status', 'el_kudo_status', 'el_reply_status'];
 
+/**
+ * Normalizes each comma-separated content-type value to its real indexed form.
+ * @param {string} rawValue - e.g. "Community;Community|Questions" or "TypeA,TypeB"
+ * @returns {string} normalized value, e.g. "Community|Questions"
+ */
+export function normalizeContentTypeFilterValue(rawValue) {
+  return (rawValue || '')
+    .split(',')
+    .map((segment) => segment.trim())
+    .filter(Boolean)
+    .map((segment) => {
+      const parts = segment
+        .split(';')
+        .map((part) => part.trim())
+        .filter(Boolean);
+      return parts[parts.length - 1] || segment;
+    })
+    .join(',');
+}
+
 // Mobile Only (Until 1024px)
 export const isMobile = () => window.matchMedia('(max-width: 1023px)').matches;
 

--- a/scripts/browse-card/browse-cards-constants.js
+++ b/scripts/browse-card/browse-cards-constants.js
@@ -54,17 +54,20 @@ export const BASE_COVEO_ADVANCED_QUERY = '(@el_contenttype NOT "Community|User")
 export const BASE_COVEO_ADVANCED_QUERY_UPCOMING_EVENT =
   '(@el_contenttype = "Event") OR (@el_contenttype = "Upcoming Event")';
 /**
- * Upcoming events that have not started yet.
+ * Upcoming events that have not started yet (Events Hub / Upcoming Event V2).
  *
- * Coveo stages `el_event_start_time` as a string field, so date operators like
- * `@el_event_start_time >= now` are ignored. Event start is reflected on the
- * standard Date field `@date` (verified against stage Events Hub), which does
- * support `>= now`. Prefer switching `el_event_start_time` to a Date field in
- * Coveo when available, then update this expression.
+ * Uses `el_event_start_time` (the same value shown as the event date on cards).
+ * Requires Coveo field type **Date** — if the field is still String, `>= now` is
+ * ignored and all Upcoming return. Do not use `@date`: on prod it is index/batch
+ * time (same for all Upcoming), so `@date >= now` drops every Upcoming.
+ *
+ * Depends on: Coveo change String → Date for `el_event_start_time` + reindex.
  *
  * @see https://docs.coveo.com/en/1814/ (date operators, `now`)
+ * @see EXLM-5361
  */
-export const COVEO_UPCOMING_EVENT_STILL_FUTURE_AQ = '(@el_contenttype = "Event|Upcoming Event" AND @date >= now)';
+export const COVEO_UPCOMING_EVENT_STILL_FUTURE_AQ =
+  '(@el_contenttype = "Event|Upcoming Event" AND @el_event_start_time >= now)';
 export const BASE_COVEO_ADVANCED_QUERY_EVENTS = `(@el_contenttype = "Event|On Demand Event") OR ${COVEO_UPCOMING_EVENT_STILL_FUTURE_AQ}`;
 /**
  * Exclude stale Upcoming Events while keeping all other content types.

--- a/scripts/search/search.js
+++ b/scripts/search/search.js
@@ -126,33 +126,13 @@ export function getHeaderSearchFilterValue(searchOptions, { preferCommunity = fa
   return defaultValue;
 }
 
-/**
- * Normalizes each comma-separated content-type value to its real indexed form.
- * @param {string} rawValue - e.g. "Community;Community|Questions" or "TypeA,TypeB"
- * @returns {string} normalized value, e.g. "Community|Questions"
- */
-export function normalizeContentTypeFilterValue(rawValue) {
-  return (rawValue || '')
-    .split(',')
-    .map((segment) => segment.trim())
-    .filter(Boolean)
-    .map((segment) => {
-      const parts = segment
-        .split(';')
-        .map((part) => part.trim())
-        .filter(Boolean);
-      return parts[parts.length - 1] || segment;
-    })
-    .join(',');
-}
-
 // Redirects to the search page based on the provided search input and filters
 export const redirectToSearchPage = (searchUrl, searchInput, filters = '') => {
   pushTopNavSearchEvent(filters, searchInput);
 
   const isLegacySearch = searchUrl.includes('.html');
   let targetUrlWithLanguage = isLegacySearch ? `${searchUrl}?lang=${languageCode}` : searchUrl;
-  const filterValue = filters?.toLowerCase() === 'all' ? '' : normalizeContentTypeFilterValue(filters);
+  const filterValue = filters?.toLowerCase() === 'all' ? '' : filters;
   if (searchInput) {
     const trimmedSearchInput = encodeURIComponent(searchInput.trim());
     targetUrlWithLanguage += `#q=${trimmedSearchInput}`;


### PR DESCRIPTION
Please provide the Jira Issue your PR is for.

<!-- Please also provide test paths following the template below. -->

Jira ID:

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://main--exlm-stage--adobe-experience-league.aem.live
- After: https://main--exlm-stage--adobe-experience-league.aem.live/en/browse?martech=off
- After: https://main--exlm-stage--adobe-experience-league.aem.live/en/browse/analytics?martech=off
- After: https://main--exlm-stage--adobe-experience-league.aem.live/en/docs?martech=off
- After: https://main--exlm-stage--adobe-experience-league.aem.live/en/docs/analytics?martech=off
- After: https://main--exlm-stage--adobe-experience-league.aem.live/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://main--exlm-stage--adobe-experience-league.aem.live/en/events?martech=off
- After: https://main--exlm-stage--adobe-experience-league.aem.live/en/playlists?martech=off
- After: https://main--exlm-stage--adobe-experience-league.aem.live/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://main--exlm-stage--adobe-experience-league.aem.live/en/perspectives?martech=off
- After: https://main--exlm-stage--adobe-experience-league.aem.live/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://main--exlm-stage--adobe-experience-league.aem.live/en/certification-home?martech=off
- After: https://main--exlm-stage--adobe-experience-league.aem.live/en/search?martech=off

## AI Review Notes

<!--
  Optional — fill this in to guide the automated Claude review.
  Each bullet tells Claude to accept the decision and not flag it.
  Examples:
    - Using inline style on `.hero` because the value comes from a content attribute and cannot be a class.
    - Skipping IntersectionObserver on this block — the third-party script must load eagerly per vendor requirement.
    - The eslint-disable on line 42 is intentional: the rule false-positives on this pattern.
-->