### PR TITLE
Revert "Community search displays incorrect content type filters-fix"…

### DIFF
--- a/blocks/atomic-search/atomic-search.js
+++ b/blocks/atomic-search/atomic-search.js
@@ -16,7 +16,6 @@ import {
   debounce,
   generateAdobeTrackingData,
   resolveBlockLevelSkeleton,
-  normalizeContentTypeFilterValue,
 } from './components/atomic-search-utils.js';
 import { isMobile } from '../header/header-utils.js';
 import { COVEO_SEARCH_CUSTOM_EVENTS } from '../../scripts/search/search-utils.js';
@@ -30,48 +29,7 @@ import { COVEO_EXCLUDE_STALE_UPCOMING_AQ } from '../../scripts/browse-card/brows
 
 let placeholders = {};
 
-/**
- * Some search entry points (e.g. the community platform's native search box) send Coveo's raw
- * "Parent;Parent|Child" indexing notation, which is never a valid filter — sanitize it here too.
- */
-function normalizeContentTypeHash() {
-  const hash = window.location.hash.slice(1);
-  if (!hash) return;
-
-  let changed = false;
-  const updatedSegments = hash.split('&').map((segment) => {
-    const eqIndex = segment.indexOf('=');
-    if (eqIndex === -1) return segment;
-    const key = segment.slice(0, eqIndex);
-    const rawValue = segment.slice(eqIndex + 1);
-    if (key !== 'f-el_contenttype' || !rawValue) return segment;
-
-    const normalizedValue = rawValue
-      .split(',')
-      .map((item) => {
-        try {
-          return encodeURIComponent(normalizeContentTypeFilterValue(decodeURIComponent(item)));
-        } catch {
-          // Malformed percent-encoding in an externally-constructed URL — leave this value as-is
-          // rather than let decorate() throw and take down the whole block's render.
-          return item;
-        }
-      })
-      .join(',');
-
-    if (normalizedValue === rawValue) return segment;
-    changed = true;
-    return `${key}=${normalizedValue}`;
-  });
-
-  if (!changed) return;
-  const newHash = updatedSegments.join('&');
-  window.history.replaceState(null, '', `${window.location.pathname}${window.location.search}#${newHash}`);
-}
-
 export default function decorate(block) {
-  normalizeContentTypeHash();
-
   const renderAtomicShimmer = (insertBefore) => {
     const skeletonWrapper = htmlToElement(`<div class="atomic-search-load-skeleton">
       <div class="atomic-load-skeleton-head">

--- a/blocks/atomic-search/components/atomic-search-utils.js
+++ b/blocks/atomic-search/components/atomic-search-utils.js
@@ -29,26 +29,6 @@ export const COMMUNITY_CONTENT_TYPES = [
 
 export const COMMUNITY_SUPPORTED_SORT_ELEMENTS = ['el_view_status', 'el_kudo_status', 'el_reply_status'];
 
-/**
- * Normalizes each comma-separated content-type value to its real indexed form.
- * @param {string} rawValue - e.g. "Community;Community|Questions" or "TypeA,TypeB"
- * @returns {string} normalized value, e.g. "Community|Questions"
- */
-export function normalizeContentTypeFilterValue(rawValue) {
-  return (rawValue || '')
-    .split(',')
-    .map((segment) => segment.trim())
-    .filter(Boolean)
-    .map((segment) => {
-      const parts = segment
-        .split(';')
-        .map((part) => part.trim())
-        .filter(Boolean);
-      return parts[parts.length - 1] || segment;
-    })
-    .join(',');
-}
-
 // Mobile Only (Until 1024px)
 export const isMobile = () => window.matchMedia('(max-width: 1023px)').matches;
 


### PR DESCRIPTION
… (#2811)

* Revert "Community search displays incorrect content type filters-fix"

* Update search.js

Please provide the Jira Issue your PR is for.

<!-- Please also provide test paths following the template below. -->

Jira ID:

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://EXLM-5449-revert-sync--exlm-stage--adobe-experience-league.aem.live
- After: https://EXLM-5449-revert-sync--exlm-stage--adobe-experience-league.aem.live/en/browse?martech=off
- After: https://EXLM-5449-revert-sync--exlm-stage--adobe-experience-league.aem.live/en/browse/analytics?martech=off
- After: https://EXLM-5449-revert-sync--exlm-stage--adobe-experience-league.aem.live/en/docs?martech=off
- After: https://EXLM-5449-revert-sync--exlm-stage--adobe-experience-league.aem.live/en/docs/analytics?martech=off
- After: https://EXLM-5449-revert-sync--exlm-stage--adobe-experience-league.aem.live/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://EXLM-5449-revert-sync--exlm-stage--adobe-experience-league.aem.live/en/events?martech=off
- After: https://EXLM-5449-revert-sync--exlm-stage--adobe-experience-league.aem.live/en/playlists?martech=off
- After: https://EXLM-5449-revert-sync--exlm-stage--adobe-experience-league.aem.live/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://EXLM-5449-revert-sync--exlm-stage--adobe-experience-league.aem.live/en/perspectives?martech=off
- After: https://EXLM-5449-revert-sync--exlm-stage--adobe-experience-league.aem.live/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://EXLM-5449-revert-sync--exlm-stage--adobe-experience-league.aem.live/en/certification-home?martech=off
- After: https://EXLM-5449-revert-sync--exlm-stage--adobe-experience-league.aem.live/en/search?martech=off

## AI Review Notes

<!--
  Optional — fill this in to guide the automated Claude review.
  Each bullet tells Claude to accept the decision and not flag it.
  Examples:
    - Using inline style on `.hero` because the value comes from a content attribute and cannot be a class.
    - Skipping IntersectionObserver on this block — the third-party script must load eagerly per vendor requirement.
    - The eslint-disable on line 42 is intentional: the rule false-positives on this pattern.
-->